### PR TITLE
Update 050-add-prisma-migrate-to-a-project.mdx

### DIFF
--- a/content/300-guides/025-migrate/100-developing-with-prisma-migrate/050-add-prisma-migrate-to-a-project.mdx
+++ b/content/300-guides/025-migrate/100-developing-with-prisma-migrate/050-add-prisma-migrate-to-a-project.mdx
@@ -58,7 +58,7 @@ To create a baseline migration:
 
    <Admonition>
 
-   Then `0_` is important because Prisma Migrate applies migrations in a [lexicographic order](https://en.wikipedia.org/wiki/Lexicographic_order). You can use a different value such as the current timestamp.
+   The `0_` is important because Prisma Migrate applies migrations in a [lexicographic order](https://en.wikipedia.org/wiki/Lexicographic_order). You can use a different value such as the current timestamp.
 
    </Admonition>
 


### PR DESCRIPTION
Update 'Then' to 'The'.

## Describe this PR

Improve grammar in documentation.

## Changes

- Changed 'Then' to 'The'

## What issue does this fix?

Documentation quality.
